### PR TITLE
Using namespace to clean up code

### DIFF
--- a/include/QPSolver.h
+++ b/include/QPSolver.h
@@ -14,8 +14,11 @@
 #define QPSOLVER_H_
 
 #include <Eigen/Dense>                                                                              // Linear algebra and matrix decomposition
-#include <iostream>                                                                                 // std::cerr, std::cout
-#include <vector>                                                                                   // std::vector
+#include <iostream>                                                                                 // cerr, cout
+#include <vector>                                                                                   // vector
+
+using namespace Eigen; // Eigen::Dynamic, Eigen::Matrix
+using namespace std;   // std::invalid_argument, std::to_string
 
 template <class DataType = float>
 class QPSolver
@@ -25,56 +28,56 @@ class QPSolver
 			
 		// These methods can be called without creating an object of this class
 		
-		static Eigen::Matrix<DataType, Eigen::Dynamic, 1>
-		solve(const Eigen::Matrix<DataType, Eigen::Dynamic, Eigen::Dynamic> &H,
-                      const Eigen::Matrix<DataType, Eigen::Dynamic, 1>              &f);
+		static Matrix<DataType, Dynamic, 1>
+		solve(const Matrix<DataType, Dynamic, Dynamic> &H,
+                      const Matrix<DataType, Dynamic, 1>       &f);
 	
 		                                      
-		static Eigen::Matrix<DataType, Eigen::Dynamic, 1>
-		least_squares(const Eigen::Matrix<DataType, Eigen::Dynamic, 1>              &y,
-			      const Eigen::Matrix<DataType, Eigen::Dynamic, Eigen::Dynamic> &A,
-			      const Eigen::Matrix<DataType, Eigen::Dynamic, Eigen::Dynamic> &W);
+		static Matrix<DataType, Dynamic, 1>
+		least_squares(const Matrix<DataType, Dynamic, 1>       &y,
+			      const Matrix<DataType, Dynamic, Dynamic> &A,
+			      const Matrix<DataType, Dynamic, Dynamic> &W);
 
-		static Eigen::Matrix<DataType, Eigen::Dynamic, 1>
-		redundant_least_squares(const Eigen::Matrix<DataType, Eigen::Dynamic, 1>              &xd,
-		                        const Eigen::Matrix<DataType, Eigen::Dynamic, Eigen::Dynamic> &W,
-		                        const Eigen::Matrix<DataType, Eigen::Dynamic, Eigen::Dynamic> &A,
-		                        const Eigen::Matrix<DataType, Eigen::Dynamic, 1>              &y);
+		static Matrix<DataType, Dynamic, 1>
+		redundant_least_squares(const Matrix<DataType, Dynamic, 1>       &xd,
+		                        const Matrix<DataType, Dynamic, Dynamic> &W,
+		                        const Matrix<DataType, Dynamic, Dynamic> &A,
+		                        const Matrix<DataType, Dynamic, 1>       &y);
 		                                                         
 		// These methods require an object since they rely on the interior point solver
 		
-		Eigen::Matrix<DataType, Eigen::Dynamic, 1>
-		constrained_least_squares(const Eigen::Matrix<DataType, Eigen::Dynamic, 1>              &y,
-		                          const Eigen::Matrix<DataType, Eigen::Dynamic, Eigen::Dynamic> &A,
-		                          const Eigen::Matrix<DataType, Eigen::Dynamic, Eigen::Dynamic> &W,
-		                          const Eigen::Matrix<DataType, Eigen::Dynamic, 1>              &xMin,
-		                          const Eigen::Matrix<DataType, Eigen::Dynamic, 1>              &xMax,
-		                          const Eigen::Matrix<DataType, Eigen::Dynamic, 1>              &x0);
+		Matrix<DataType, Dynamic, 1>
+		constrained_least_squares(const Matrix<DataType, Dynamic, 1>       &y,
+		                          const Matrix<DataType, Dynamic, Dynamic> &A,
+		                          const Matrix<DataType, Dynamic, Dynamic> &W,
+		                          const Matrix<DataType, Dynamic, 1>       &xMin,
+		                          const Matrix<DataType, Dynamic, 1>       &xMax,
+		                          const Matrix<DataType, Dynamic, 1>       &x0);
 		                                        
-		Eigen::Matrix<DataType, Eigen::Dynamic, 1>
-		constrained_least_squares(const Eigen::Matrix<DataType, Eigen::Dynamic, 1>              &xd,
-		                          const Eigen::Matrix<DataType, Eigen::Dynamic, Eigen::Dynamic> &W,
-		                          const Eigen::Matrix<DataType, Eigen::Dynamic, Eigen::Dynamic> &A,
-		                          const Eigen::Matrix<DataType, Eigen::Dynamic, 1>              &y,
-		                          const Eigen::Matrix<DataType, Eigen::Dynamic, 1>              &xMin,
-		                          const Eigen::Matrix<DataType, Eigen::Dynamic, 1>              &xMax,
-		                          const Eigen::Matrix<DataType, Eigen::Dynamic, 1>              &x0);
+		Matrix<DataType, Dynamic, 1>
+		constrained_least_squares(const Matrix<DataType, Dynamic, 1>       &xd,
+		                          const Matrix<DataType, Dynamic, Dynamic> &W,
+		                          const Matrix<DataType, Dynamic, Dynamic> &A,
+		                          const Matrix<DataType, Dynamic, 1>       &y,
+		                          const Matrix<DataType, Dynamic, 1>       &xMin,
+		                          const Matrix<DataType, Dynamic, 1>       &xMax,
+		                          const Matrix<DataType, Dynamic, 1>       &x0);
 		
-		Eigen::Matrix<DataType, Eigen::Dynamic, 1>
-		constrained_least_squares(const Eigen::Matrix<DataType, Eigen::Dynamic, 1>              &xd,
-		                          const Eigen::Matrix<DataType, Eigen::Dynamic, Eigen::Dynamic> &W,
-		                          const Eigen::Matrix<DataType, Eigen::Dynamic, Eigen::Dynamic> &A,
-		                          const Eigen::Matrix<DataType, Eigen::Dynamic, 1>              &y,
-		                          const Eigen::Matrix<DataType, Eigen::Dynamic, Eigen::Dynamic> &B,
-		                          const Eigen::Matrix<DataType, Eigen::Dynamic, 1>              &z,
-		                          const Eigen::Matrix<DataType, Eigen::Dynamic, 1>              &x0);
+		Matrix<DataType, Dynamic, 1>
+		constrained_least_squares(const Matrix<DataType, Dynamic, 1>       &xd,
+		                          const Matrix<DataType, Dynamic, Dynamic> &W,
+		                          const Matrix<DataType, Dynamic, Dynamic> &A,
+		                          const Matrix<DataType, Dynamic, 1>       &y,
+		                          const Matrix<DataType, Dynamic, Dynamic> &B,
+		                          const Matrix<DataType, Dynamic, 1>       &z,
+		                          const Matrix<DataType, Dynamic, 1>       &x0);
 		
-		Eigen::Matrix<DataType, Eigen::Dynamic, 1>  
-		solve(const Eigen::Matrix<DataType, Eigen::Dynamic, Eigen::Dynamic> &H,
-		      const Eigen::Matrix<DataType, Eigen::Dynamic, 1>              &f,
-		      const Eigen::Matrix<DataType, Eigen::Dynamic, Eigen::Dynamic> &B,
-		      const Eigen::Matrix<DataType, Eigen::Dynamic, 1>              &z,
-		      const Eigen::Matrix<DataType, Eigen::Dynamic, 1>              &x0);
+		Matrix<DataType, Dynamic, 1>  
+		solve(const Matrix<DataType, Dynamic, Dynamic> &H,
+		      const Matrix<DataType, Dynamic, 1>       &f,
+		      const Matrix<DataType, Dynamic, Dynamic> &B,
+		      const Matrix<DataType, Dynamic, 1>       &z,
+		      const Matrix<DataType, Dynamic, 1>       &x0);
 		      
 		// Methods for setting properties in the interior point solver
 		
@@ -88,7 +91,9 @@ class QPSolver
 		
 		bool set_barrier_reduction_rate(const DataType &rate);
 		
-		Eigen::Matrix<DataType, Eigen::Dynamic, Eigen::Dynamic> last_solution() const { return this->lastSolution; }
+		Matrix<DataType, Dynamic, Dynamic> last_solution() const { return this->lastSolution; }
+		
+		void clear_last_solution() { this->lastSolution.clear(); }
 		
 	private:
 		
@@ -101,37 +106,36 @@ class QPSolver
 		
 		int steps = 20;                                                                     // No. of steps to run interior point method
 		
-		Eigen::Matrix<DataType, Eigen::Dynamic, Eigen::Dynamic> lastSolution;               // Can be used for future use
+		Matrix<DataType, Dynamic, Dynamic> lastSolution;                                    // Can be used for future use
 		
 		DataType min(const DataType &a, const DataType &b)
 		{
-			DataType minimum = (a < b) ? a : b;                                         // std::min doesn't like floats ಠ_ಠ
+			DataType minimum = (a < b) ? a : b;                                         // min doesn't like floats ಠ_ಠ
 			return minimum;
 		}
 		
 };                                                                                                  // Required after class declaration
 
-
   ////////////////////////////////////////////////////////////////////////////////////////////////////
  //              Solve a standard QP problem of the form min 0.5*x'*H*x + x'*f                     //
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 template <class DataType> inline
-Eigen::Matrix<DataType, Eigen::Dynamic, 1>
-QPSolver<DataType>::solve(const Eigen::Matrix<DataType, Eigen::Dynamic, Eigen::Dynamic> &H,
-		          const Eigen::Matrix<DataType, Eigen::Dynamic, 1>              &f)
+Matrix<DataType, Dynamic, 1>
+QPSolver<DataType>::solve(const Matrix<DataType, Dynamic, Dynamic> &H,
+		          const Matrix<DataType, Dynamic, 1>       &f)
 {
 	if(H.rows() != H.cols())
 	{
-		throw std::invalid_argument("[ERROR] [QP SOLVER] solve(): "
-		                            "Expected a square matrix for the Hessian H but it was "
-		                            + std::to_string(H.rows()) + "x" + std::to_string(H.cols()) + ".");
+		throw invalid_argument("[ERROR] [QP SOLVER] solve(): "
+		                       "Expected a square matrix for the Hessian H but it was "
+		                       + to_string(H.rows()) + "x" + to_string(H.cols()) + ".");
 	}
 	else if(H.rows() != f.rows())
 	{	
-		throw std::invalid_argument("[ERROR] [QP SOLVER] solve(): "
-		                            "Dimensions of arguments do not match. "
-		                            "The Hessian H was " + std::to_string(H.rows()) + "x" + std::to_string(H.cols()) +
-		                            " and the f vector was " + std::to_string(f.size()) + "x1.");
+		throw invalid_argument("[ERROR] [QP SOLVER] solve(): "
+		                       "Dimensions of arguments do not match. "
+		                       "The Hessian H was " + to_string(H.rows()) + "x" + to_string(H.cols()) +
+		                       " and the f vector was " + to_string(f.size()) + "x1.");
 	}
 	else 	return H.ldlt().solve(-f);                                                          // Too easy lol ᕙ(▀̿̿ĺ̯̿̿▀̿ ̿) ᕗ
 }
@@ -140,31 +144,31 @@ QPSolver<DataType>::solve(const Eigen::Matrix<DataType, Eigen::Dynamic, Eigen::D
  //           Solve an unconstrained least squares problem: min 0.5(y-A*x)'*W*(y-A*x)              //
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 template <class DataType> inline
-Eigen::Matrix<DataType, Eigen::Dynamic, 1>
-QPSolver<DataType>::least_squares(const Eigen::Matrix<DataType, Eigen::Dynamic, 1>              &y,
-                                  const Eigen::Matrix<DataType, Eigen::Dynamic, Eigen::Dynamic> &A,
-                                  const Eigen::Matrix<DataType, Eigen::Dynamic, Eigen::Dynamic> &W)
+Matrix<DataType, Dynamic, 1>
+QPSolver<DataType>::least_squares(const Matrix<DataType, Dynamic, 1>       &y,
+                                  const Matrix<DataType, Dynamic, Dynamic> &A,
+                                  const Matrix<DataType, Dynamic, Dynamic> &W)
 {
 	if(A.rows() < A.cols())                                                                     // Redundant system, use other function
 	{
-		throw std::invalid_argument("[ERROR] [QP SOLVER] least_squares(): "
-		                            "The A matrix has more rows than columns ("
-		                            + std::to_string(A.rows()) + "x" + std::to_string(A.cols()) + "). "
-		                            "Did you mean to call the function for redundant least squares?");	                    		                   
+		throw invalid_argument("[ERROR] [QP SOLVER] least_squares(): "
+		                       "The A matrix has more rows than columns ("
+		                       + to_string(A.rows()) + "x" + to_string(A.cols()) + "). "
+		                       "Did you mean to call redundant_least_squares()?");	                    		                   
 	}
 	if(W.rows() != W.cols())
 	{
-		throw std::invalid_argument("[ERROR] [QP SOLVER] least_squares(): "
-		                            "Expected a square weighting matrix W but it was "
-		                            + std::to_string(W.rows()) + "x" + std::to_string(W.cols()) + ".");
+		throw invalid_argument("[ERROR] [QP SOLVER] least_squares(): "
+		                       "Expected a square weighting matrix W but it was "
+		                       + to_string(W.rows()) + "x" + to_string(W.cols()) + ".");
 	}
 	else if(y.rows() != W.rows() and W.cols() != A.rows())
 	{
-		throw std::invalid_argument("[ERROR] [QP SOLVER] least_squares(): "
-		                            "Dimensions of input arguments do not match. "
-		                            "The y vector was " + std::to_string(y.size()) + "x1, "
-		                            "the A matrix had " + std::to_string(A.rows()) + " rows, and "
-		                            "the weighting matrix W was " + std::to_string(W.rows()) + "x" + std::to_string(W.cols()) + ".");
+		throw invalid_argument("[ERROR] [QP SOLVER] least_squares(): "
+		                       "Dimensions of input arguments do not match. "
+		                       "The y vector was " + to_string(y.size()) + "x1, "
+		                       "the A matrix had " + to_string(A.rows()) + " rows, and "
+		                       "the weighting matrix W was " + to_string(W.rows()) + "x" + to_string(W.cols()) + ".");
 	}
 	else	return (A.transpose()*W*A).ldlt().solve(A.transpose()*W*y);                         // x = (A'*W*A)^-1*A'*W*y
 }
@@ -173,43 +177,43 @@ QPSolver<DataType>::least_squares(const Eigen::Matrix<DataType, Eigen::Dynamic, 
  //    Solve least squares problem of the form min 0.5*(xd - x)'*W*(xd - x) subject to: A*x = y    //
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 template <class DataType> inline
-Eigen::Matrix<DataType, Eigen::Dynamic, 1>
-QPSolver<DataType>::redundant_least_squares(const Eigen::Matrix<DataType, Eigen::Dynamic, 1>              &xd,
-                                            const Eigen::Matrix<DataType, Eigen::Dynamic, Eigen::Dynamic> &W,
-                                            const Eigen::Matrix<DataType, Eigen::Dynamic, Eigen::Dynamic> &A,
-                                            const Eigen::Matrix<DataType, Eigen::Dynamic, 1>              &y)
+Matrix<DataType, Dynamic, 1>
+QPSolver<DataType>::redundant_least_squares(const Matrix<DataType, Dynamic, 1>       &xd,
+                                            const Matrix<DataType, Dynamic, Dynamic> &W,
+                                            const Matrix<DataType, Dynamic, Dynamic> &A,
+                                            const Matrix<DataType, Dynamic, 1>       &y)
 {
 	if(A.rows() >= A.cols())
 	{
-		throw std::invalid_argument("[ERROR] [QP SOLVER] redundant_least_squares(): "
-		                            "The equality constraint matrix has more rows than columns ("
-		                            + std::to_string(A.rows()) + " >= " + std::to_string(A.cols()) + "). "
-		                            "Did you mean to call the other least squares function?");
+		throw invalid_argument("[ERROR] [QP SOLVER] redundant_least_squares(): "
+		                       "The equality constraint matrix has more rows than columns ("
+		                       + to_string(A.rows()) + " >= " + to_string(A.cols()) + "). "
+		                       "Did you mean to call the other least squares function?");
 	}
 	else if(W.rows() != W.cols())
 	{
-		throw std::invalid_argument("[ERROR] [QP SOLVER] redundant_least_squares(): "
-		                            "Expected the weighting matrix to be square but it was "
-		                            + std::to_string(W.rows()) + "x" + std::to_string(W.cols()) + ".");
+		throw invalid_argument("[ERROR] [QP SOLVER] redundant_least_squares(): "
+		                       "Expected the weighting matrix to be square but it was "
+		                       + to_string(W.rows()) + "x" + to_string(W.cols()) + ".");
 	}
 	else if(xd.size() != W.rows() or W.cols() != A.cols())
 	{	
-		throw std::invalid_argument("[ERROR] [QP SOLVER] redundant_least_squares(): "
-		                            "Dimensions for the decision variable do not match. "
-		                            "The desired vector had " + std::to_string(xd.size()) + " elements, "
-		                            "the weighting matrix was " + std::to_string(W.rows()) + "x" + std::to_string(W.cols()) + ", and "
-		                            "the constraint matrix had " + std::to_string(A.cols()) + " columns.");
+		throw invalid_argument("[ERROR] [QP SOLVER] redundant_least_squares(): "
+		                       "Dimensions for the decision variable do not match. "
+		                       "The desired vector had " + to_string(xd.size()) + " elements, "
+		                       "the weighting matrix was " + to_string(W.rows()) + "x" + to_string(W.cols()) + ", and "
+		                       "the constraint matrix had " + to_string(A.cols()) + " columns.");
         }
         else if(y.size() != A.rows())
         {    	
-        	throw std::invalid_argument("[ERROR] [QP SOLVER] redundant_least_squares(): "
-        	                            "Dimensions for the equality constraint do not match. "
-        	                            "The constraint vector had " + std::to_string(y.size()) + " elements, and "
-        	                            "the constraint matrix had " + std::to_string(A.rows()) + " rows.");
+        	throw invalid_argument("[ERROR] [QP SOLVER] redundant_least_squares(): "
+        	                       "Dimensions for the equality constraint do not match. "
+        	                       "The constraint vector had " + to_string(y.size()) + " elements, and "
+        	                       "the constraint matrix had " + to_string(A.rows()) + " rows.");
         }
         else
         {   		
-		Eigen::MatrixXf B = W.ldlt().solve(A.transpose());                                  // Makes calcs a little easier
+		MatrixXf B = W.ldlt().solve(A.transpose());                                         // Makes calcs a little easier
 		
 		return xd + B*(A*B).ldlt().solve(y - A*xd);                                         // xd - W^-1*A'*(A*W^-1*A')^-1*(y-A*xd)
 	}
@@ -219,34 +223,37 @@ QPSolver<DataType>::redundant_least_squares(const Eigen::Matrix<DataType, Eigen:
  //      Solve a constrained problem: min 0.5*(y - A*x)'*W*(y - A*x) s.t. xMin <= x <= xMax        //
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 template <class DataType> inline
-Eigen::Matrix<DataType, Eigen::Dynamic, 1>
-QPSolver<DataType>::constrained_least_squares(const Eigen::Matrix<DataType, Eigen::Dynamic, 1>              &y,
-                                              const Eigen::Matrix<DataType, Eigen::Dynamic, Eigen::Dynamic> &A,
-                                              const Eigen::Matrix<DataType, Eigen::Dynamic, Eigen::Dynamic> &W,
-                                              const Eigen::Matrix<DataType, Eigen::Dynamic, 1>              &xMin,
-                                              const Eigen::Matrix<DataType, Eigen::Dynamic, 1>              &xMax,
-                                              const Eigen::Matrix<DataType, Eigen::Dynamic, 1>              &x0)
+Matrix<DataType, Dynamic, 1>
+QPSolver<DataType>::constrained_least_squares(const Matrix<DataType, Dynamic, 1>       &y,
+                                              const Matrix<DataType, Dynamic, Dynamic> &A,
+                                              const Matrix<DataType, Dynamic, Dynamic> &W,
+                                              const Matrix<DataType, Dynamic, 1>       &xMin,
+                                              const Matrix<DataType, Dynamic, 1>       &xMax,
+                                              const Matrix<DataType, Dynamic, 1>       &x0)
 {
 	// Check that the inputs are sound
 	if(y.rows() != A.rows() or A.rows() != W.rows())
 	{
-		throw std::invalid_argument("[ERROR] [QP SOLVER] constrained_least_squares(): Dimensions of arguments do not match. "
-		                            "The y vector argument had " + std::to_string(y.rows()) + " rows, "
-		                            "the A matrix argument had " + std::to_string(A.rows()) + " rows, and "
-		                            "the weighting matrix argument W was " + std::to_string(W.rows()) + "x" + std::to_string(W.cols()) + ".");
+		throw invalid_argument("[ERROR] [QP SOLVER] constrained_least_squares(): "
+		                       "Dimensions of arguments do not match. "
+		                       "The y vector argument had " + to_string(y.rows()) + " rows, "
+		                       "the A matrix argument had " + to_string(A.rows()) + " rows, and "
+		                       "the weighting matrix argument W was " + to_string(W.rows()) + "x" + to_string(W.cols()) + ".");
 	}
 	else if(W.rows() != W.cols())
 	{
-		throw std::invalid_argument("[ERROR] [QP SOLVER] constrained_least_squares(): Expected the weighting matrix W to be "
-		                            "square but it was " + std::to_string(W.rows()) + "x" + std::to_string(W.cols()) + ".");
+		throw invalid_argument("[ERROR] [QP SOLVER] constrained_least_squares(): "
+		                       "Expected the weighting matrix W to be square but "
+		                       "it was " + to_string(W.rows()) + "x" + to_string(W.cols()) + ".");
 	}
 	else if(A.cols() != xMin.rows() or xMin.rows() != xMax.rows() or xMax.rows() != x0.rows())
 	{
-		throw std::invalid_argument("[ERROR] [QP SOLVER] constrained_least_squares(): Dimensions of arguments do not match. "
-		                            "The A matrix had " + std::to_string(A.cols()) + " columns, "
-		                            "the xMin vector had " + std::to_string(xMin.rows()) + " rows, "
-		                            "the xMax vector had " + std::to_string(xMax.rows()) + " rows, "
-		                            "and the start point vector x0 had " + std::to_string(x0.rows()) + " rows.");
+		throw invalid_argument("[ERROR] [QP SOLVER] constrained_least_squares(): "
+		                       "Dimensions of arguments do not match. "
+		                       "The A matrix had " + to_string(A.cols()) + " columns, "
+		                       "the xMin vector had " + to_string(xMin.rows()) + " rows, "
+		                       "the xMax vector had " + to_string(xMax.rows()) + " rows, "
+		                       "and the start point vector x0 had " + to_string(x0.rows()) + " rows.");
 	}
 	
 	unsigned int n = x0.size();
@@ -255,15 +262,15 @@ QPSolver<DataType>::constrained_least_squares(const Eigen::Matrix<DataType, Eige
 	// B = [  I ]   z = [ xMax ]
 	//     [ -I ]       [ xMin ]
 	
-	Eigen::Matrix<DataType,Eigen::Dynamic,Eigen::Dynamic> B(2*n,n);
+	Matrix<DataType,Dynamic,Dynamic> B(2*n,n);
 	B.block(0,0,n,n).setIdentity();
 	B.block(n,0,n,n) = -B.block(0,0,n,n);
 	
-	Eigen::Matrix<DataType,Eigen::Dynamic,1> z(2*n);
+	Matrix<DataType,Dynamic,1> z(2*n);
 	z.head(n) =  xMax;
 	z.tail(n) = -xMin;
 	
-	Eigen::Matrix<DataType, Eigen::Dynamic, Eigen::Dynamic> AtW = A.transpose()*W;              // Makes calcs a little easier
+	Matrix<DataType, Dynamic, Dynamic> AtW = A.transpose()*W;                                   // Makes calcs a little easier
 	
 	this->lastSolution = solve(AtW*A, -AtW*y, B, z, x0);                                        // Convert to standard QP problem and solve
 	
@@ -274,40 +281,40 @@ QPSolver<DataType>::constrained_least_squares(const Eigen::Matrix<DataType, Eige
  //         Solve a constrained problem min 0.5*(xd - x)'*W*(xd - x) s.t. A*x = y, B*x <= z        //
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 template <class DataType> inline
-Eigen::Matrix<DataType, Eigen::Dynamic, 1>
-QPSolver<DataType>::constrained_least_squares(const Eigen::Matrix<DataType, Eigen::Dynamic, 1>              &xd,
-                                              const Eigen::Matrix<DataType, Eigen::Dynamic, Eigen::Dynamic> &W,
-                                              const Eigen::Matrix<DataType, Eigen::Dynamic, Eigen::Dynamic> &A,
-                                              const Eigen::Matrix<DataType, Eigen::Dynamic, 1>              &y,
-                                              const Eigen::Matrix<DataType, Eigen::Dynamic, 1>              &xMin,
-                                              const Eigen::Matrix<DataType, Eigen::Dynamic, 1>              &xMax,
-                                              const Eigen::Matrix<DataType, Eigen::Dynamic, 1>              &x0)
+Matrix<DataType, Dynamic, 1>
+QPSolver<DataType>::constrained_least_squares(const Matrix<DataType, Dynamic, 1>       &xd,
+                                              const Matrix<DataType, Dynamic, Dynamic> &W,
+                                              const Matrix<DataType, Dynamic, Dynamic> &A,
+                                              const Matrix<DataType, Dynamic, 1>       &y,
+                                              const Matrix<DataType, Dynamic, 1>       &xMin,
+                                              const Matrix<DataType, Dynamic, 1>       &xMax,
+                                              const Matrix<DataType, Dynamic, 1>       &x0)
 {
 	// Check that the dimensions of the inputs are sound
 	if(xd.size() != W.rows()    or W.rows()    != A.cols()
 	or A.cols()  != xMin.size() or xMin.size() != xMax.size() or xMax.size() != x0.size())
 	{
-		throw std::invalid_argument("[ERROR] [QP SOLVER] constrained_least_squares(): "
-		                            "Dimensions of input arguments do not match. "
-		                            "The desired vector xd had " + std::to_string(xd.size()) + " elements, "
-		                            "the weighting matrix W was " + std::to_string(W.rows()) + "x" + std::to_string(W.cols()) + ", "
-		                            "the A matrix had " + std::to_string(A.cols()) + " columns, "
-		                            "the xMin vector had " + std::to_string(xMin.size()) + " elements, "
-		                            "the xMax vector had " + std::to_string(xMax.size()) + " elements, and "
-		                            "the start point x0 had " + std::to_string(x0.size()) + " elements.");
+		throw invalid_argument("[ERROR] [QP SOLVER] constrained_least_squares(): "
+		                       "Dimensions of input arguments do not match. "
+		                       "The desired vector xd had " + to_string(xd.size()) + " elements, "
+		                       "the weighting matrix W was " + to_string(W.rows()) + "x" + to_string(W.cols()) + ", "
+		                       "the A matrix had " + to_string(A.cols()) + " columns, "
+		                       "the xMin vector had " + to_string(xMin.size()) + " elements, "
+		                       "the xMax vector had " + to_string(xMax.size()) + " elements, and "
+		                       "the start point x0 had " + to_string(x0.size()) + " elements.");
 	}
 	else if(W.rows() != W.cols())
 	{
-		throw std::invalid_argument("[ERROR] [QP SOLVER] constrained_least_squares(): "
-		                            "Expected the weighting matrix W to be squares, "
-		                            "but it was " + std::to_string(W.rows()) + "x" + std::to_string(W.cols()) + ".");
+		throw invalid_argument("[ERROR] [QP SOLVER] constrained_least_squares(): "
+		                       "Expected the weighting matrix W to be squares, "
+		                       "but it was " + to_string(W.rows()) + "x" + to_string(W.cols()) + ".");
 	}
 	else if(A.rows() != y.size())
 	{
-		throw std::invalid_argument("[ERROR] [QP SOLVER] constrained_least_squares(): "
-		                            "Dimensions for the equality constraint do not match. "
-		                            "The A matrix had " + std::to_string(A.rows()) + " rows, and "
-		                            "the y vector had " + std::to_string(y.size()) + " elements.");
+		throw invalid_argument("[ERROR] [QP SOLVER] constrained_least_squares(): "
+		                       "Dimensions for the equality constraint do not match. "
+		                       "The A matrix had " + to_string(A.rows()) + " rows, and "
+		                       "the y vector had " + to_string(y.size()) + " elements.");
 	}
 	
 	// Primal:
@@ -322,18 +329,18 @@ QPSolver<DataType>::constrained_least_squares(const Eigen::Matrix<DataType, Eige
 	// subject to B*x < z
 	
 	// Variables used in this scope:
-	Eigen::Matrix<DataType, Eigen::Dynamic, 1> f;                                               // Linear part of QP
-	Eigen::Matrix<DataType, Eigen::Dynamic, 1> z;                                               // Constraint vector	
-	Eigen::Matrix<DataType, Eigen::Dynamic, Eigen::Dynamic> H;                                  // Hessian
-	Eigen::Matrix<DataType, Eigen::Dynamic, Eigen::Dynamic> B;                                  // Constraint matrix
+	Matrix<DataType, Dynamic, 1> f;                                                             // Linear part of QP
+	Matrix<DataType, Dynamic, 1> z;                                                             // Constraint vector	
+	Matrix<DataType, Dynamic, Dynamic> H;                                                       // Hessian
+	Matrix<DataType, Dynamic, Dynamic> B;                                                       // Constraint matrix
 	
 	unsigned int n = x0.size();                                                                 // Number of dimensions in the problem
 		
-	Eigen::Matrix<DataType,Eigen::Dynamic,Eigen::Dynamic> invWAt = W.ldlt().solve(A.transpose()); // Makes calcs a little easier
+	Matrix<DataType,Dynamic,Dynamic> invWAt = W.ldlt().solve(A.transpose());                    // Makes calcs a little easier
 	
-	H = A*invWAt;                                                                       // Hessian matrix for the dual problem
+	H = A*invWAt;                                                                               // Hessian matrix for the dual problem
 	
-	Eigen::LDLT<Eigen::Matrix<DataType,Eigen::Dynamic,Eigen::Dynamic>> Hdecomp;         // LDLT decomposition of the Hessian
+	Eigen::LDLT<Matrix<DataType,Dynamic,Dynamic>> Hdecomp;                                      // LDLT decomposition of the Hessian
 	Hdecomp.compute(H);                                                                 
 	
 	// Convert the constraints to standard form: B*x <= z
@@ -349,19 +356,19 @@ QPSolver<DataType>::constrained_least_squares(const Eigen::Matrix<DataType, Eige
 	z.tail(n) = -xMin;
 	
 	// Ensure null space projection of the desired solution xd is feasible
-	Eigen::Matrix<DataType,Eigen::Dynamic,1> xn = xd - invWAt*Hdecomp.solve(A*xd);      // xd projected on to null space of A matrix
+	Matrix<DataType,Dynamic,1> xn = xd - invWAt*Hdecomp.solve(A*xd);                            // xd projected on to null space of A matrix
 	
-	float alpha = 1.0;                                                                  // Scalar
+	float alpha = 1.0;                                                                          // Scalar
 	
 	for(int i = 0; i < n; i++)
 	{
-		     if(xn(i) >= xMax(i)) alpha = min(0.9*xMax(i)/xn(i), alpha);            // If over the limit, reduce alpha
+		     if(xn(i) >= xMax(i)) alpha = min(0.9*xMax(i)/xn(i), alpha);                    // If over the limit, reduce alpha
 		else if(xn(i) <= xMin(i)) alpha = min(0.9*xMin(i)/xn(i), alpha);
 	}
 	
-	xn = alpha*xd;                                                                      // New desired vector
+	xn = alpha*xd;                                                                              // New desired vector
 	
-	f = A*xn - y;                                                                       // Linear component of QP
+	f = A*xn - y;                                                                               // Linear component of QP
 	
 	this->lastSolution = xn + invWAt*solve(H, f, B*invWAt, z - B*xn, Hdecomp.solve(A*(x0 - xn)));
 	
@@ -407,7 +414,7 @@ QPSolver<DataType>::constrained_least_squares(const Eigen::Matrix<DataType, Eige
 	
 	this->lastSolution = solve(H,f,B,z,startPoint).tail(n);
 
-	return this->lastSolution;                                                          // Convert to standard form and solve
+	return this->lastSolution;                                                                  // Convert to standard form and solve
 	*/
 }
 
@@ -415,12 +422,12 @@ QPSolver<DataType>::constrained_least_squares(const Eigen::Matrix<DataType, Eige
  //          Solve a problem of the form: min 0.5*x'*H*x + x'*f subject to: B*x <= z              //        
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 template <class DataType> inline
-Eigen::Matrix<DataType, Eigen::Dynamic, 1>
-QPSolver<DataType>::solve(const Eigen::Matrix<DataType, Eigen::Dynamic, Eigen::Dynamic> &H,
-                          const Eigen::Matrix<DataType, Eigen::Dynamic, 1>              &f,
-                          const Eigen::Matrix<DataType, Eigen::Dynamic, Eigen::Dynamic> &B,
-                          const Eigen::Matrix<DataType, Eigen::Dynamic, 1>              &z,
-                          const Eigen::Matrix<DataType, Eigen::Dynamic, 1>              &x0)
+Matrix<DataType, Dynamic, 1>
+QPSolver<DataType>::solve(const Matrix<DataType, Dynamic, Dynamic> &H,
+                          const Matrix<DataType, Dynamic, 1>       &f,
+                          const Matrix<DataType, Dynamic, Dynamic> &B,
+                          const Matrix<DataType, Dynamic, 1>       &z,
+                          const Matrix<DataType, Dynamic, 1>       &x0)
 {
 	unsigned int dim = x0.rows();                                                               // Number of dimensions
 
@@ -429,22 +436,22 @@ QPSolver<DataType>::solve(const Eigen::Matrix<DataType, Eigen::Dynamic, Eigen::D
 	// Check that the inputs are sound
 	if(H.rows() != H.cols())
 	{
-		throw std::invalid_argument("[ERROR] [QP SOLVER] solve(): Expected a square matrix for the Hessian "
-		                            "but it was " + std::to_string(H.rows()) + "x" + std::to_string(H.cols()) + ".");
+		throw invalid_argument("[ERROR] [QP SOLVER] solve(): Expected a square matrix for the Hessian "
+		                       "but it was " + to_string(H.rows()) + "x" + to_string(H.cols()) + ".");
 	}
 	else if(H.rows() != dim or f.rows() != dim or B.cols() != dim)
 	{
-		throw std::invalid_argument("[ERROR] [QP SOLVER] solve(): Dimensions for the decision variable do not match. "
-		                            "The Hessian was " + std::to_string(H.rows()) + "x" + std::to_string(H.cols()) + ", "
-		                            "the f vector was " + std::to_string(f.rows()) + "x1, "
-		                            "the constraint matrix had " + std::to_string(B.cols()) + " columns, and "
-		                            "the start point was " + std::to_string(x0.rows()) + "x1.");
+		throw invalid_argument("[ERROR] [QP SOLVER] solve(): Dimensions for the decision variable do not match. "
+		                       "The Hessian was " + to_string(H.rows()) + "x" + to_string(H.cols()) + ", "
+		                       "the f vector was " + to_string(f.rows()) + "x1, "
+		                       "the constraint matrix had " + to_string(B.cols()) + " columns, and "
+		                       "the start point was " + to_string(x0.rows()) + "x1.");
 	}
 	else if(B.rows() != z.rows())
 	{
-		throw std::invalid_argument("[ERROR] [QP SOLVER] solve(): Dimensions for the constraints do not match. "
-		                            "The constraint matrix had " + std::to_string(B.rows()) + " rows, and "
-		                            "the constraint vector had " + std::to_string(z.rows()) + " rows.");
+		throw invalid_argument("[ERROR] [QP SOLVER] solve(): Dimensions for the constraints do not match. "
+		                       "The constraint matrix had " + to_string(B.rows()) + " rows, and "
+		                       "the constraint vector had " + to_string(z.rows()) + " rows.");
 	}
 	
 	// Solve the following optimization problem with Guass-Newton method:
@@ -463,15 +470,15 @@ QPSolver<DataType>::solve(const Eigen::Matrix<DataType, Eigen::Dynamic, Eigen::D
 	DataType u;                                                                                 // Scalar for the barrier function
 	DataType alpha;                                                                             // Scalar on the Newton step
 	
-	Eigen::Matrix<DataType, Eigen::Dynamic, 1> g(dim);                                          // Gradient vector
-	Eigen::Matrix<DataType, Eigen::Dynamic, 1> x = x0;                                          // Value to be returned
-	Eigen::Matrix<DataType, Eigen::Dynamic, 1> dx(dim);                                         // Newton step = -I^-1*g
-	Eigen::Matrix<DataType, Eigen::Dynamic, Eigen::Dynamic> I;                                  // Hessian with added barrier function
+	Matrix<DataType, Dynamic, 1> g(dim);                                                        // Gradient vector
+	Matrix<DataType, Dynamic, 1> x = x0;                                                        // Value to be returned
+	Matrix<DataType, Dynamic, 1> dx(dim);                                                       // Newton step = -I^-1*g
+	Matrix<DataType, Dynamic, Dynamic> I;                                                       // Hessian with added barrier function
 
-	std::vector<DataType> d; d.resize(numConstraints);                                          // Distance to every constraint
+	vector<DataType> d; d.resize(numConstraints);                                               // Distance to every constraint
 	
 	// Make sure the start point is inside the constraints	
-	Eigen::Matrix<DataType,Eigen::Dynamic,1> blah(dim);
+	Matrix<DataType,Dynamic,1> blah(dim);
 	
 	if(numConstraints < dim) blah = B.transpose()*(B*B.transpose()).ldlt().solve(z);            // Project constraint back to state space
 	else                     blah = (B.transpose()*B).ldlt().solve(B.transpose()*z);
@@ -486,8 +493,8 @@ QPSolver<DataType>::solve(const Eigen::Matrix<DataType, Eigen::Dynamic, Eigen::D
 	}
 	
 	// Do some pre-processing
-	std::vector<Eigen::Matrix<DataType,Eigen::Dynamic,1>> bt(numConstraints);                   // Row vectors of B matrix transposed
-	std::vector<Eigen::Matrix<DataType,Eigen::Dynamic,Eigen::Dynamic>> btb(numConstraints);     // Outer product of row vectors
+	vector<Matrix<DataType,Dynamic,1>> bt(numConstraints);                                      // Row vectors of B matrix transposed
+	vector<Matrix<DataType,Dynamic,Dynamic>> btb(numConstraints);                               // Outer product of row vectors
 	
 	for(int j = 0; j < numConstraints; j++)
 	{
@@ -510,7 +517,7 @@ QPSolver<DataType>::solve(const Eigen::Matrix<DataType, Eigen::Dynamic, Eigen::D
 			/* Old code no longer necessary
 			if(d[j] <= 0)
 			{
-			//	if(i == 0) throw std::runtime_error("[ERROR] [QP SOLVER] solve(): Start point is outside the constraints.");
+			//	if(i == 0) throw runtime_error("[ERROR] [QP SOLVER] solve(): Start point is outside the constraints.");
 				
 				u   *= 100;                                                         // Increase the barrier function
 				d[j] = 1e-04;                                                       // Set a small, non-zero value
@@ -559,10 +566,9 @@ bool QPSolver<DataType>::set_step_size(const DataType &scalar)
 {
 	if(scalar <= 0)
 	{
-		std::cerr << "[ERROR] [QP SOLVER] set_step_size(): "
-		          << "Input argument was " << std::to_string(scalar) << " "
-		          << "but it must be positive.\n";
-		
+		cerr << "[ERROR] [QP SOLVER] set_step_size(): "
+		     << "Input argument was " << to_string(scalar) << " but it must be positive.\n";
+	
 		return false;
 	}
 	else
@@ -581,9 +587,8 @@ bool QPSolver<DataType>::set_barrier_reduction_rate(const DataType &rate)
 {
 	if(rate <= 0 or rate >= 1)
 	{
-		std::cerr << "[ERROR] [QP SOLVER] set_barrier_reduction_rate(): "
-		             "Input argument was " << std::to_string(rate) << " "
-		             "but it must be between 0 and 1.\n";
+		cerr << "[ERROR] [QP SOLVER] set_barrier_reduction_rate(): "
+		        "Input argument was " << to_string(rate) << " but it must be between 0 and 1.\n";
 		             
 		return false;
 	}
@@ -603,9 +608,8 @@ bool QPSolver<DataType>::set_tolerance(const DataType &tolerance)
 {
 	if(tolerance <= 0)
 	{
-		std::cerr << "[ERROR] [QP SOLVER] set_tolerance(): "
-		          << "Input argument was " << std::to_string(tolerance) << " "
-		          << "but it must be positive.\n";
+		cerr << "[ERROR] [QP SOLVER] set_tolerance(): "
+		     << "Input argument was " << to_string(tolerance) << " but it must be positive.\n";
 		 
 		return false;
 	}
@@ -625,8 +629,8 @@ bool QPSolver<DataType>::set_num_steps(const unsigned int &number)
 {
 	if(number == 0)
 	{
-		std::cerr << "[ERROR] [QP SOLVER] set_num_steps(): "
-		          << "Input argument was 0 but it must be greater than zero.\n";
+		cerr << "[ERROR] [QP SOLVER] set_num_steps(): "
+		     << "Input argument was 0 but it must be greater than zero.\n";
 		
 		return false;
 	}
@@ -646,9 +650,8 @@ bool QPSolver<DataType>::set_barrier_scalar(const DataType &scalar)
 {
 	if(scalar <= 0)
 	{
-		std::cerr << "[ERROR] [QP SOLVER] set_barrier_scalar(): "
-		          << "Input argument was " << std::to_string(scalar) << " "
-		          << "but it must be positive.\n";
+		cerr << "[ERROR] [QP SOLVER] set_barrier_scalar(): "
+		     << "Input argument was " << to_string(scalar) << " but it must be positive.\n";
 		
 		return false;
 	}


### PR DESCRIPTION
Changed all cases using `Eigen::` and `std::` as namespaces to improve readability.